### PR TITLE
Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following content to the file.
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "xj-view": "workspace:^"
+    "xj-fv": "workspace:^"
   }
 }
 ```
@@ -53,7 +53,7 @@ export default defineConfig({
   esbuild: {
     jsxFactory: '__jsx.h',
     jsxFragment: '__jsx.Fragment',
-    jsxInject: `import { __jsx } from 'xj-view'`,
+    jsxInject: `import { __jsx } from 'xj-fv'`,
   },
 })
 ```
@@ -78,7 +78,7 @@ export default defineConfig({
 **main.jsx**
 
 ```jsx
-import { createRoot, expose } from 'xj-view'
+import { createRoot, expose } from 'xj-fv'
 
 const app = createRoot(document.getElementById('main')).render(
   <h1>hello XJ</h1>,

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,7 +34,7 @@ build指令依赖于[`tsc`](https://www.typescriptlang.org/docs/handbook/compile
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "xj-view": "workspace:^"
+    "xj-fv": "workspace:^"
   }
 }
 ```
@@ -53,7 +53,7 @@ export default defineConfig({
   esbuild: {
     jsxFactory: '__jsx.h',
     jsxFragment: '__jsx.Fragment',
-    jsxInject: `import { __jsx } from 'xj-view'`,
+    jsxInject: `import { __jsx } from 'xj-fv'`,
   },
 })
 ```
@@ -78,7 +78,7 @@ export default defineConfig({
 **main.jsx**
 
 ```jsx
-import { createRoot, expose } from 'xj-view'
+import { createRoot, expose } from 'xj-fv'
 
 const app = createRoot(document.getElementById('main')).render(
   <h1>hello XJ</h1>,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "keywords": [
     "xj",
-    "xj-view"
+    "xj-fv"
   ],
   "author": "XunJiJiang",
   "license": "MIT",

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xj-view/runtime-core",
+  "name": "@xj-fv/runtime-core",
   "version": "0.0.1",
   "description": "The runtime-core of the fast framework xj",
   "main": "./src/index.ts",
@@ -22,7 +22,7 @@
   },
   "keywords": [
     "xj",
-    "xj-view"
+    "xj-fv"
   ],
   "repository": {
     "type": "git",
@@ -33,6 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "reflect-metadata": "^0.2.2",
-    "@xj-view/shared": "workspace:^"
+    "@xj-fv/shared": "workspace:^"
   }
 }

--- a/packages/runtime-core/src/component.ts
+++ b/packages/runtime-core/src/component.ts
@@ -8,7 +8,7 @@ import {
   isBoolean,
   isElement,
   isFunction,
-} from '@xj-view/shared'
+} from '@xj-fv/shared'
 
 export type XJData = Record<string, unknown>
 

--- a/packages/runtime-core/src/expose.ts
+++ b/packages/runtime-core/src/expose.ts
@@ -1,4 +1,4 @@
-import { extend } from '@xj-view/shared'
+import { extend } from '@xj-fv/shared'
 
 import { type XJData } from './component'
 

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,5 +1,5 @@
 // import { createNode } from './node'
-import { isElement } from '@xj-view/shared'
+import { isElement } from '@xj-fv/shared'
 
 export const createRoot = (container: Element) => {
   if (!isElement(container)) {

--- a/packages/runtime-core/src/node.ts
+++ b/packages/runtime-core/src/node.ts
@@ -19,7 +19,7 @@ import {
   toLowerCase,
   // isKnownHtmlAttr,
   // isBooleanAttr,
-} from '@xj-view/shared'
+} from '@xj-fv/shared'
 
 import {
   type XJData,

--- a/packages/runtime-core/src/prop.ts
+++ b/packages/runtime-core/src/prop.ts
@@ -9,7 +9,7 @@ import {
   isElement,
   isHTMLElement,
   isNumber,
-} from '@xj-view/shared'
+} from '@xj-fv/shared'
 
 import {
   type XJComponent,

--- a/packages/runtime-dom/package.json
+++ b/packages/runtime-dom/package.json
@@ -22,7 +22,7 @@
   },
   "keywords": [
     "xj",
-    "xj-view"
+    "xj-fv"
   ],
   "repository": {
     "type": "git",
@@ -33,6 +33,6 @@
   "license": "MIT",
   "dependencies": {
     "reflect-metadata": "^0.2.2",
-    "@xj-view/shared": "workspace:^"
+    "@xj-fv/shared": "workspace:^"
   }
 }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,1 +1,1 @@
-# @xj-view/shared
+# @xj-fv/shared

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@xj-view/shared",
+  "name": "@xj-fv/shared",
   "version": "0.0.1",
   "description": "The shared of the fast framework xj",
   "main": "./src/index.ts",
@@ -22,7 +22,7 @@
   },
   "keywords": [
     "xj",
-    "xj-view"
+    "xj-fv"
   ],
   "repository": {
     "type": "git",

--- a/packages/xj/package.json
+++ b/packages/xj/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xj-view",
+  "name": "xj-fv",
   "version": "0.0.1",
   "description": "A fast framework",
   "main": "./src/index.ts",
@@ -22,7 +22,7 @@
   },
   "keywords": [
     "xj",
-    "xj-view"
+    "xj-fv"
   ],
   "repository": {
     "type": "git",
@@ -32,8 +32,8 @@
   "author": "XunJiJiang",
   "license": "MIT",
   "dependencies": {
-    "@xj-view/shared": "workspace:^",
-    "@xj-view/runtime-core": "workspace:^",
+    "@xj-fv/shared": "workspace:^",
+    "@xj-fv/runtime-core": "workspace:^",
     "reflect-metadata": "^0.2.2"
   }
 }

--- a/packages/xj/runtime-jsx/index.d.ts
+++ b/packages/xj/runtime-jsx/index.d.ts
@@ -1,4 +1,4 @@
-import type { ReservedProps } from '@xj-view/runtime-core'
+import type { ReservedProps } from '@xj-fv/runtime-core'
 import type { NativeElements } from './jsx'
 
 /**
@@ -10,7 +10,7 @@ export {
   createNode as jsx,
   createNode as jsxDEV,
   Fragment,
-} from '@xj-view/runtime-core'
+} from '@xj-fv/runtime-core'
 
 export namespace JSX {
   export interface ElementClass {

--- a/packages/xj/runtime-jsx/index.js
+++ b/packages/xj/runtime-jsx/index.js
@@ -1,4 +1,4 @@
-const { createNode, Fragment } = require('@xj-view/runtime-core')
+const { createNode, Fragment } = require('@xj-fv/runtime-core')
 
 function jsx(type, props, key) {
   const { children } = props

--- a/packages/xj/runtime-jsx/index.mjs
+++ b/packages/xj/runtime-jsx/index.mjs
@@ -1,4 +1,4 @@
-import { createNode, Fragment } from '@xj-view/runtime-core'
+import { createNode, Fragment } from '@xj-fv/runtime-core'
 
 function jsx(type, props, key) {
   const { children } = props

--- a/packages/xj/runtime-jsx/jsx.ts
+++ b/packages/xj/runtime-jsx/jsx.ts
@@ -1350,7 +1350,7 @@ type EventHandlers<E> = {
     : (payload: E[K]) => void
 }
 
-import type { XJData } from '@xj-view/runtime-core'
+import type { XJData } from '@xj-fv/runtime-core'
 
 export type ReservedProps = {
   key?: string | number

--- a/packages/xj/src/index.ts
+++ b/packages/xj/src/index.ts
@@ -1,4 +1,4 @@
-// import { shared } from '@xj-view/shared';
+// import { shared } from '@xj-fv/shared';
 import 'reflect-metadata'
 import {
   createNode,
@@ -6,7 +6,7 @@ import {
   createRoot,
   expose,
   h,
-} from '@xj-view/runtime-core'
+} from '@xj-fv/runtime-core'
 
 const xj = {
   createNode,
@@ -27,6 +27,6 @@ export {
   createRoot,
   expose,
   h,
-} from '@xj-view/runtime-core'
+} from '@xj-fv/runtime-core'
 
 export default xj

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -136,7 +136,7 @@ function createConfig(target, format, output, plugins = [], sourcemap = false) {
     // requires a ton of template engines which should be ignored.
     /** @type {ReadonlyArray<string>} */
     let cjsIgnores = []
-    // if (pkg.name === '@xj-view/shared') {}
+    // if (pkg.name === '@xj-fv/shared') {}
 
     const nodePlugins =
       format === 'cjs' && Object.keys(pkg.devDependencies || {}).length

--- a/scripts/aliases.js
+++ b/scripts/aliases.js
@@ -18,8 +18,8 @@ const dirs = readdirSync(new URL('../packages', import.meta.url))
 const entries = {
   xj: resolveEntryForPkg('xj'),
   // '@xj/types': resolveTypesEntryForPkg('xj'),
-  // '@xj-view/shared': resolveEntryForPkg('shared'),
-  // '@xj-view/shared/types': resolveTypesEntryForPkg('shared'),
+  // '@xj-fv/shared': resolveEntryForPkg('shared'),
+  // '@xj-fv/shared/types': resolveTypesEntryForPkg('shared'),
 }
 
 const nonSrcPackages = []

--- a/scripts/create-package.js
+++ b/scripts/create-package.js
@@ -34,7 +34,7 @@ function createPackage(packageName, authorName, dependencies) {
     scripts: {
       test: 'echo "Error: no test specified" && exit 1',
     },
-    keywords: ['xj', 'xj-view'],
+    keywords: ['xj', 'xj-fv'],
     author: authorName,
     license: 'MIT',
     dependencies,


### PR DESCRIPTION
* feat(runtime-core): Removed support for children as function

* refactor(runtime-core):Modify the calling logic of collectExpose

* docs: add keyword

* refactor(xj): delete @xj/runtime-dom in dependencies

* refactor: [@xj](https://github.com/xj) -> [@xj-view](https://github.com/xj-view) because name is taken